### PR TITLE
text overflow issue fixed

### DIFF
--- a/src/components/UI/BackgroundGraident/BackgroundGradient.jsx
+++ b/src/components/UI/BackgroundGraident/BackgroundGradient.jsx
@@ -36,11 +36,11 @@ const BackgroundGradient = ({ hashValue, title, className }) => {
       )}
     >
       <div
-        className={` ${
+        className={`max-w-[250px] overflow-hidden text-ellipsis ${
           selectedMode === 'light' ? 'text-neutral-800' : 'text-neutral-400'
         }`}
       >
-        {nameShortner(title, 100)}
+        {nameShortner(title, 60)}
       </div>
     </div>
   );


### PR DESCRIPTION
fixes #205 
This PR fixes the text overflow issue from the container.
actually the problem wasn't in the description length because some sentences of same length are taking different spaces because of the font.. so i hid the overflowed text and gave a max-width to the container and added an ellipsis to the text.

i am attaching before and after ss.
![Screenshot (176)](https://github.com/linkcollect/Main-Website-Linkcollect/assets/95524790/41d57453-1090-4751-bf9a-14c152b474cf)
![Screenshot (177)](https://github.com/linkcollect/Main-Website-Linkcollect/assets/95524790/2723933f-8775-41cd-9907-0c41b9374f9d)



